### PR TITLE
Fixes for /ppimprisonany & PrisonPearlManager.imprisonPlayer()

### DIFF
--- a/src/com/untamedears/PrisonPearl/PrisonPearlCommands.java
+++ b/src/com/untamedears/PrisonPearl/PrisonPearlCommands.java
@@ -604,6 +604,10 @@ class PrisonPearlCommands implements CommandExecutor {
         	uuid = NameAPI.getUUID(args[0]);
         else
         	uuid = Bukkit.getOfflinePlayer(args[0]).getUniqueId();
+        if (uuid == null){
+        	sender.sendMessage("No player found with the name: "+args[0]);
+        	return true;
+        }
         if (pearlman.imprisonPlayer(uuid, (Player)sender)) {
             sender.sendMessage("You imprisoned " + args[0]);
             Player imprisoned = Bukkit.getPlayer(uuid);

--- a/src/com/untamedears/PrisonPearl/managers/PrisonPearlManager.java
+++ b/src/com/untamedears/PrisonPearl/managers/PrisonPearlManager.java
@@ -57,6 +57,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.scheduler.BukkitTask;
 
 import vg.civcraft.mc.mercury.MercuryAPI;
+import vg.civcraft.mc.namelayer.NameAPI;
 
 import com.mojang.authlib.GameProfile;
 import com.untamedears.PrisonPearl.EnderExpansion;
@@ -70,12 +71,14 @@ public class PrisonPearlManager implements Listener {
 	private final PrisonPearlPlugin plugin;
 	private final PrisonPearlStorage pearls;
 	private EnderExpansion ee;
+	private boolean isNameLayer;
 	private boolean isMercury;
 
 	public PrisonPearlManager(PrisonPearlPlugin plugin, PrisonPearlStorage pearls, EnderExpansion ee) {
 		this.plugin = plugin;
 		this.pearls = pearls;
 		this.ee = ee;
+		isNameLayer = Bukkit.getPluginManager().isPluginEnabled("NameLayer");
 		isMercury = plugin.isMercuryLoaded();
 		Bukkit.getPluginManager().registerEvents(this, plugin);
 	}
@@ -159,10 +162,15 @@ public class PrisonPearlManager implements Listener {
 			return false;
 		}
 
-		OfflinePlayer pearled = Bukkit.getOfflinePlayer(imprisonedId);
 		// create the prison pearl
-		PrisonPearl pp = pearls.newPearl(pearled, imprisoner);
-		String name = pearled.getName();
+		String name = "";
+		if (isNameLayer){
+			name = NameAPI.getCurrentName(imprisonedId);
+		} else {
+	        name = Bukkit.getOfflinePlayer(imprisonedId).getName();
+		}
+		
+		PrisonPearl pp = pearls.newPearl(name, imprisonedId, imprisoner);
 		// set off an event
 		if (!prisonPearlEvent(pp, PrisonPearlEvent.Type.NEW, imprisoner)) {
 			pearls.deletePearl(pp, "Something canceled the creation of the pearl for player " + pp.getImprisonedName() +
@@ -192,7 +200,7 @@ public class PrisonPearlManager implements Listener {
 
 
                 //check if imprisoned was imprisoned by themselves
-		if(imprisoner.getUniqueId() == pearled.getUniqueId()){
+		if(imprisoner.getUniqueId() == pp.getImprisonedId()){
 			//ok player imprisoned themselves throw the pearl on the floor
 			imprisoner.getWorld().dropItem(imprisoner.getLocation(), is);
 			Bukkit.getLogger().info("Player attempted to imprison themself. Pearl was dropped");


### PR DESCRIPTION
* + Adds a check in /ppimprisonany command to check for null uuid's. This check prevents a null from propagating further down the call chain.
* & Changed parts of where an OfflinePlayer is cast to rely on namelayer first for the name. It still uses the OfflinePlayer if namelayer isn't present

This commit is meant to address issue Civcraft/PrisonPearl#40