### PR TITLE
Player Death add respect for combat tag if CT or CTP is enabled

### DIFF
--- a/src/com/untamedears/PrisonPearl/PrisonPearlPlugin.java
+++ b/src/com/untamedears/PrisonPearl/PrisonPearlPlugin.java
@@ -624,6 +624,9 @@ public class PrisonPearlPlugin extends JavaPlugin implements Listener {
 			uuid = iden.getId();
 			playerName = iden.getName();
 			log.info("NPC Player: " + playerName + ", ID: " + uuid);
+		} else if (combatTagManager.isEnabled() && !combatTagManager.isCombatTagged(player)) {
+			log.info("Player: " + playerName + " is out of combatTag, immune from pearling.");
+			return;
 		}
 		
 		PrisonPearl pp = pearls.getByImprisoned(uuid); // find out if the player is imprisoned

--- a/src/com/untamedears/PrisonPearl/managers/CombatTagManager.java
+++ b/src/com/untamedears/PrisonPearl/managers/CombatTagManager.java
@@ -24,6 +24,10 @@ public class CombatTagManager {
 	private TagManager combatTagPlusTagManager;
 	private Server server;
 
+	public boolean isEnabled() {
+		return combatTagEnabled || combatTagPlusEnabled;
+	}
+
 	public CombatTagManager(Server server, Logger l) {
 		if(server.getPluginManager().getPlugin("CombatTag") != null) {
 			combatTagApi = new CombatTagApi((CombatTag)server.getPluginManager().getPlugin("CombatTag"));


### PR DESCRIPTION
Players are getting "pearled" by non-combat deaths long after combat has ended. Easiest fix to me seems to just add respect for combat tag and remove total reliance on the damagetracker. Seems the damagetracker isn't releasing damage events appropriately; so later we can tackle root cause.

Addresses issue #74
