### PR TITLE
Fix for null pointer exception during save routine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.untamedears</groupId>
 	<artifactId>PrisonPearl</artifactId>
 	<packaging>jar</packaging>
-	<version>2.5.98</version>
+	<version>2.5.99</version>
 	<name>PrisonPearl</name>
 	<url>https://github.com/Civcraft/PrisonPearl</url>
 

--- a/src/com/untamedears/PrisonPearl/PrisonPearlPlugin.java
+++ b/src/com/untamedears/PrisonPearl/PrisonPearlPlugin.java
@@ -449,7 +449,7 @@ public class PrisonPearlPlugin extends JavaPlugin implements Listener {
 	
 	private static void save(SaveLoad obj, File file) {
 		try {
-			if (globalInstance.getMysqlStorage() == null) {
+			if (globalInstance.getMysqlStorage() != null) {
 				obj.save(null);
 				return;
 			}


### PR DESCRIPTION
Inverted logic, if mysql is disabled was sending null file pointer to save routine, should only do that if mysql is enabled.