### PR TITLE
Fixed teleport within worlds dropping pearls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.untamedears</groupId>
 	<artifactId>PrisonPearl</artifactId>
 	<packaging>jar</packaging>
-	<version>2.6.0</version>
+	<version>2.6.1</version>
 	<name>PrisonPearl</name>
 	<url>https://github.com/Civcraft/PrisonPearl</url>
 

--- a/src/com/untamedears/PrisonPearl/managers/PrisonPearlManager.java
+++ b/src/com/untamedears/PrisonPearl/managers/PrisonPearlManager.java
@@ -704,6 +704,11 @@ public class PrisonPearlManager implements Listener {
 		World newWorld = to.getWorld();
 		if (!denyWorlds.contains(newWorld.getName()))
 			return;
+      
+                World oldWorld = previous.getWorld();
+                //not changing worlds, no reason to free pearls
+                if(newWorld.getName().equals(oldWorld.getName()))
+                        return;
 		
 		Inventory inv = event.getPlayer().getInventory();
 		boolean message = false;


### PR DESCRIPTION
Previously if you exited a minecart in the nether it would drop your pearls. AFAIK this was only intended to prevent pearls being brought in to the nether, not to prevent you from moving them around in the nether. This fixes that by checking if the origin and destination for the teleport are in the same world