### PR TITLE
Hide enchants for pearls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.untamedears</groupId>
 	<artifactId>PrisonPearl</artifactId>
 	<packaging>jar</packaging>
-	<version>3.0.4</version>
+	<version>3.0.5</version>
 	<name>PrisonPearl</name>
 	<url>https://github.com/Civcraft/PrisonPearl</url>
 

--- a/src/vg/civcraft/mc/prisonpearl/managers/PrisonPearlManager.java
+++ b/src/vg/civcraft/mc/prisonpearl/managers/PrisonPearlManager.java
@@ -166,6 +166,7 @@ public class PrisonPearlManager {
 		lore.add("Unique: " + pp.getUniqueIdentifier());
 		// Given enchantment effect (durability used because it doesn't affect pearl behaviour)
 		im.addEnchant(Enchantment.DURABILITY, 1, true);
+		im.addItemFlags(ItemFlag.HIDE_ENCHANTS);
 		im.setLore(lore);
 		is.setItemMeta(im);
 		// Give it to the imprisoner


### PR DESCRIPTION
This hides the enchant from players. The pearl will still glow, but players won't see the unbreaking enchant, even though it's still there.